### PR TITLE
fixing the DeprecationWarning

### DIFF
--- a/modelingprocess.py
+++ b/modelingprocess.py
@@ -60,7 +60,7 @@ def model_one_volume(data5tuple):
     newmodel.fit(trainingset, yvals)
 
     testset = (testset - means) / stdevs
-    prediction = newmodel.predict_proba(testset)[0][1]
+    prediction = newmodel.predict_proba(testset.reshape(1, -1))[0][1]
     if i % 50 == 0:
         print(i)
     # print(str(i) + "  -  " + str(len(listtoexclude)))


### PR DESCRIPTION
Running `newmodel.predict_proba()` gives the following error:

```
DeprecationWarning: Passing 1d arrays as data is deprecated in 0.17 and willraise ValueError in 0.19. Reshape your data either using X.reshape(-1, 1) if your data has a single feature or X.reshape(1, -1) if it contains a single sample.
```

The testset variable is a 1D array with an ambiguous shape (3200,), this fixes the warning by explicitly defining the shape (1,3200) [# samples, # features].
